### PR TITLE
display author and URL only if set

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,16 @@
               {{if eq .Section "post"}}
                 <well class="well">
                   <h3><a class="link" href="{{.Permalink}}">{{.Title}}</a>
-                    by <a class="link" href="{{ .Params.AuthorUrl }}">{{ .Params.Author }}</a></h3>
+                    {{ if (isset .Params "author") }}
+                    <p>by
+                        {{ if (isset .Params "author_url") }}
+                            <a href="{{ .Params.AuthorUrl }}">{{ .Params.Author }}</a>
+                        {{ else }}
+                            {{ .Params.Author }}
+                        {{ end }}
+                    </p>
+                    {{ end }}
+                    </h3>
                     <h4>{{ .PublishDate.Format "January 2, 2006" }} | Reading Time: {{.ReadingTime}} min </h4>
                     <span class="tags">
                         {{range .Params.Tags }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,15 @@
     <h2 class="post-title"><a class="go-back" href="{{ "post/" | absLangURL}}">
 	      <i class="far fa-caret-square-left"></i></a> {{.Title}}</h2>
     </div>
-    <p>By <a href="{{ .Params.AuthorUrl }}">{{ .Params.Author }}</a></p>
+    {{ if (isset .Params "author") }}
+    <p>By
+        {{ if (isset .Params "author_url") }}
+            <a href="{{ .Params.AuthorUrl }}">{{ .Params.Author }}</a>
+        {{ else }}
+            {{ .Params.Author }}
+        {{ end }}
+    </p>
+    {{ end }}
     <p class="post-dets">Published on: {{ .PublishDate.Format "January 2, 2006"}}
         | Reading Time: {{.ReadingTime}} min | Last Modified : {{ .Page.Lastmod.Format "January 2, 2006" }}
         <br>


### PR DESCRIPTION
 - if `author` is not set, nothing is displayed (as before)
 - if `author_url` is not set, only the author name, without any link, is displayed

Without this, I get weird looking "By " on every post on my blog, where I'm the only author, so this is not required.